### PR TITLE
Tweak project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build.log
 
 .idea
 *.iml
+.ijwb
 classes
 
 obj

--- a/README.md
+++ b/README.md
@@ -12,25 +12,49 @@ dependencies.
 To achieve a small binary size it eschews a single library binary that can be
 used on both Java SE and Android, and avoids the use of runtime abstractions /
 multiple implementations of classes and reflection. Instead, some classes have
-two implementations. This is handled explicitly in one branch rather than
-treating one variant as subordinate / a fork.
+two implementations. This is handled explicitly in one git repository rather
+than treating one variant as subordinate and creating a fork or branch.
 
 Targeting Java SE is intended primarily to enable fast development interation
 and testing, and size is not as much of a consideration.
 
-This project uses the [bazel](https://bazel.build/) build system.
+## Using the project
 
-## The directory structure
+To build Android targets, you will need the Android SDK installed and
+discoverable. e.g. set the ANDROID_HOME environment variable if you haven't
+already, e.g.:
+```
+export ANDROID_HOME=~/Android/Sdk/
+```
+
+### Building
+
+This project uses the [bazel](https://bazel.build/) build system.
+Once bazel is installed, commands like `bazel build` can be used to build the
+project artifacts.
+
+### Testing
+
+Execute automated tests using `blaze` commands like:
+`bazel test android/javatests/com/google/time/client/base:tests`
+
+## Developing the project
+
+### The directory structure
+
+The java-time-client project is two projects in one. There are two bazel
+WORKSPACE files, and it is structured to support work on Java SE and Android
+simultaneously.
 
 + Most code in this project can be found under `common/`.
 + `javase/` and `android/` contain the variants of the code. Common code is
   included in the variant directory structures using symlinks, which can be
   regenerated using the `regenerate-common-symlinks.sh` script.
 
-The use of symlinks in this project may make development on some platforms more
+The use of symlinks in this project may make developing on some platforms more
 difficult. Sorry.
 
-## Code style
+### Code style / formatting
 
 For Java:
 + Use https://github.com/google/google-java-format
@@ -40,12 +64,31 @@ For BUILD and related:
 + Use https://github.com/bazelbuild/buildtools
 + e.g. `buildifier -r --lint=warn .`
 
-## Packages
+### Developing with IntelliJ IDEA
 
-+ `com.google.time.client.base`: Base classes to support higher-level code.
-  These include stand-ins for various classes that are not supported on earlier
-  versions of Android.
+You don't have to use IntelliJ, but if you do...
 
-## license
++ Set ANDROID_HOME in the environment used to launch IntelliJ.
++ Install the bazel plugin as needed.
++ From "Welcome to IntelliJ", select "Import Bazel Project..."
+
+To create the Android project:
++ Select the `java-time-client/android` directory
++ Select the android/android.bazelproject file
+
+To create the Java SE project:
++ Repeat the steps used for the Android project but for
+  `java-time-client/javase` / `javase`.
+
+
+## Navigating the project
+
+### Packages / Artifacts
+
++ "base" / `com.google.time.client.base`: Base classes to support higher-level
+  code.  These include stand-ins for various classes that are not supported on
+  earlier versions of Android.
+
+## License
 
 Apache 2.0

--- a/android/WORKSPACE
+++ b/android/WORKSPACE
@@ -1,7 +1,6 @@
 # Use the Android SDK pointed to by ${ANDROID_HOME}
 android_sdk_repository(name = "androidsdk")
 
-# Required for http_archive
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # BEGIN Required for android_local_test
@@ -33,9 +32,6 @@ maven_install(
         "com.google.truth:truth:1.1.3",
         # Android test suppport
         "junit:junit:4.13.2",
-        #"javax.inject:javax.inject:1",
-        #"org.hamcrest:java-hamcrest:2.0.0.0"
-        #"androidx.test.espresso:espresso-core:3.1.1",
         "androidx.test:core:aar:1.4.0",
         "androidx.test:rules:aar:1.4.0",
         "androidx.test:runner:aar:1.4.0",

--- a/android/android.bazelproject
+++ b/android/android.bazelproject
@@ -1,0 +1,12 @@
+directories:
+  java
+  javatests
+targets:
+  //java/com/google/time/client/...
+  //javatests/com/google/time/client/...
+workspace_type: java
+additional_languages:
+  android
+java_language_level: 8
+test_sources:
+  javatests/*

--- a/android/java/com/google/time/client/base/testing/BUILD
+++ b/android/java/com/google/time/client/base/testing/BUILD
@@ -6,6 +6,6 @@ android_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
-        "//android/java/com/google/time/client/base",
+        "//java/com/google/time/client/base",
     ],
 )

--- a/android/javatests/com/google/time/client/base/BUILD
+++ b/android/javatests/com/google/time/client/base/BUILD
@@ -4,8 +4,8 @@ gen_android_local_tests(
     name = "tests",
     srcs = glob(["*.java"]),
     deps = [
-        "//android/java/com/google/time/client/base",
-        "//android/java/com/google/time/client/base/testing",
+        "//java/com/google/time/client/base",
+        "//java/com/google/time/client/base/testing",
         "@maven//:com_google_truth_truth",
         "@maven//:org_robolectric_robolectric",
         "@robolectric//bazel:android-all",

--- a/android/javatests/com/google/time/client/base/testing/BUILD
+++ b/android/javatests/com/google/time/client/base/testing/BUILD
@@ -4,8 +4,8 @@ gen_android_local_tests(
     name = "tests",
     srcs = glob(["*.java"]),
     deps = [
-        "//android/java/com/google/time/client/base",
-        "//android/java/com/google/time/client/base/testing",
+        "//java/com/google/time/client/base",
+        "//java/com/google/time/client/base/testing",
         "@maven//:com_google_truth_truth",
         "@maven//:org_robolectric_robolectric",
         "@robolectric//bazel:android-all",

--- a/javase/WORKSPACE
+++ b/javase/WORKSPACE
@@ -1,0 +1,33 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# BEGIN maven support
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+    strip_prefix = "rules_jvm_external-4.2",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.2.zip",
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        # Truth
+        "com.google.truth:truth:1.1.3",
+    ],
+    repositories = [
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+# END maven support
+
+# BEGIN bazel-common imports
+http_archive(
+    name = "google_bazel_common",
+    sha256 = "d8aa0ef609248c2a494d5dbdd4c89ef2a527a97c5a87687e5a218eb0b77ff640",
+    strip_prefix = "bazel-common-4a8d451e57fb7e1efecbf9495587a10684a19eb2",
+    urls = ["https://github.com/google/bazel-common/archive/4a8d451e57fb7e1efecbf9495587a10684a19eb2.zip"],
+)
+# END bazel-common imports
+

--- a/javase/java/com/google/time/client/base/testing/BUILD
+++ b/javase/java/com/google/time/client/base/testing/BUILD
@@ -4,6 +4,6 @@ java_library(
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "//javase/java/com/google/time/client/base",
+        "//java/com/google/time/client/base",
     ],
 )

--- a/javase/javase.bazelproject
+++ b/javase/javase.bazelproject
@@ -1,0 +1,10 @@
+directories:
+  java
+  javatests
+targets:
+  //java/com/google/time/client/...
+  //javatests/com/google/time/client/...
+workspace_type: java
+java_language_level: 8
+test_sources:
+  javatests/*

--- a/javase/javatests/com/google/time/client/base/BUILD
+++ b/javase/javatests/com/google/time/client/base/BUILD
@@ -4,8 +4,8 @@ gen_java_tests(
     name = "tests",
     srcs = glob(["*.java"]),
     deps = [
-        "//javase/java/com/google/time/client/base",
-        "//javase/java/com/google/time/client/base/testing",
+        "//java/com/google/time/client/base",
+        "//java/com/google/time/client/base/testing",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],

--- a/javase/javatests/com/google/time/client/base/testing/BUILD
+++ b/javase/javatests/com/google/time/client/base/testing/BUILD
@@ -4,8 +4,8 @@ gen_java_tests(
     name = "tests",
     srcs = glob(["*.java"]),
     deps = [
-        "//javase/java/com/google/time/client/base",
-        "//javase/java/com/google/time/client/base/testing",
+        "//java/com/google/time/client/base",
+        "//java/com/google/time/client/base/testing",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
     ],


### PR DESCRIPTION
Split the project into 2 bazel workspaces to ease IntelliJ setup and
adjust the BUILD / WORKSPACE files accordingly.

Add 2 .bazelproject files.

Extend the README.md with more details.

Update .gitignore to exclude bazel plugin directories.