### PR TITLE
Switch to "client data minimization" by default

### DIFF
--- a/common/java/com/google/time/client/sntp/BasicSntpClient.java
+++ b/common/java/com/google/time/client/sntp/BasicSntpClient.java
@@ -93,6 +93,7 @@ public final class BasicSntpClient implements SntpClient {
     private InstantSource clientInstantSource = PlatformInstantSource.instance();
     private Ticker clientTicker = PlatformTicker.instance();
     private Network network = PlatformNetwork.instance();
+    private boolean clientDataMinimizationEnabled = true;
 
     // Properties without defaults.
     private ClientConfig clientConfig;
@@ -127,8 +128,18 @@ public final class BasicSntpClient implements SntpClient {
       return this;
     }
 
+    /**
+     * Sets whether to use client data minimization suggested in <a
+     * href="https://datatracker.ietf.org/doc/html/draft-ietf-ntp-data-minimization-04"
+     * >draft-ietf-ntp-data-minimization-04</a>. The default is enabled.
+     */
+    public Builder setClientDataMinimizationEnabled(boolean enabled) {
+      this.clientDataMinimizationEnabled = enabled;
+      return this;
+    }
+
     /** Sets the {@link ClientConfig config} to use. */
-    public Builder setConfig(ClientConfig clientConfig) {
+    public Builder setClientConfig(ClientConfig clientConfig) {
       this.clientConfig = Objects.requireNonNull(clientConfig);
       return this;
     }
@@ -142,6 +153,7 @@ public final class BasicSntpClient implements SntpClient {
           new SntpConnectorImpl(
               logger, network, clientInstantSource, clientTicker, listener, clientConfig);
       SntpClientEngine engine = new SntpClientEngine(logger, sntpConnector);
+      engine.setClientDataMinimizationEnabled(clientDataMinimizationEnabled);
       return new BasicSntpClient(engine, clientInstantSource);
     }
   }

--- a/javase/java/com/google/time/client/sntp/tools/SntpComparisonTool.java
+++ b/javase/java/com/google/time/client/sntp/tools/SntpComparisonTool.java
@@ -58,7 +58,7 @@ public final class SntpComparisonTool {
         ClientConfig clientConfig = createIpAddressConfig(expandedAddress, serverAddress.getPort());
 
         BasicSntpClient client =
-            new BasicSntpClient.Builder().setConfig(clientConfig).setLogger(logger).build();
+            new BasicSntpClient.Builder().setClientConfig(clientConfig).setLogger(logger).build();
         try {
           SntpResult sntpResult = client.requestInstant();
 

--- a/javase/java/com/google/time/client/sntp/tools/SntpTool.java
+++ b/javase/java/com/google/time/client/sntp/tools/SntpTool.java
@@ -46,7 +46,7 @@ public final class SntpTool {
     Ticker clientTicker = PlatformTicker.instance();
     BasicSntpClient client =
         new BasicSntpClient.Builder()
-            .setConfig(clientConfig)
+            .setClientConfig(clientConfig)
             .setClientTicker(clientTicker)
             .setLogger(logger)
             .build();


### PR DESCRIPTION
The original NTP specs suggest sending the client's instant in the NTP
request (optionally, with some randomization of the lower bits rather
than zero if the instant source has only millis precision).

https://datatracker.ietf.org/doc/html/draft-ietf-ntp-data-minimization-04
suggests this is an unnecessary "leak" of client information since the
information is not needed by the client.

This commit switches to sending a entirely random value by default. The
new behavior can be turned off if required.