### PR TITLE
Changes from trial import into Android platform

### DIFF
--- a/android/WORKSPACE
+++ b/android/WORKSPACE
@@ -1,7 +1,7 @@
 # Use the Android SDK pointed to by ${ANDROID_HOME}
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 19,
+    api_level = 26,
     # This version is needed for dx, which is used by bazel android_ rules.
     build_tools_version = "30.0.3",
 )
@@ -38,6 +38,8 @@ maven_install(
         # Mockito
         "org.mockito:mockito-android:jar:3.0.0",
         "org.mockito:mockito-core:jar:3.0.0",
+        # Android annotation support
+        "androidx.annotation:annotation:aar:1.3.0",
         # Android test suppport
         "junit:junit:4.13.2",
         "androidx.test:core:aar:1.4.0",

--- a/android/java/com/google/time/client/base/BUILD.bazel
+++ b/android/java/com/google/time/client/base/BUILD.bazel
@@ -6,4 +6,5 @@ android_library(
         "impl/*.java",
     ]),
     visibility = ["//visibility:public"],
+    deps = ["@maven//:androidx_annotation_annotation"],
 )

--- a/android/java/com/google/time/client/base/Duration.java
+++ b/android/java/com/google/time/client/base/Duration.java
@@ -21,6 +21,8 @@ import static com.google.time.client.base.impl.DateTimeConstants.MILLISECONDS_PE
 import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_MILLISECOND;
 import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_SECOND;
 
+import android.os.Build;
+import androidx.annotation.RequiresApi;
 import com.google.time.client.base.impl.ExactMath;
 import com.google.time.client.base.impl.Objects;
 import java.math.BigDecimal;
@@ -46,6 +48,12 @@ public final class Duration implements Comparable<Duration> {
   public static Duration ofNanos(long nanos) {
     long seconds = nanos / NANOS_PER_SECOND;
     long nanosAdjustment = nanos % NANOS_PER_SECOND;
+    return ofSeconds(seconds, nanosAdjustment);
+  }
+
+  public static Duration ofMillis(long millis) {
+    long seconds = millis / MILLISECONDS_PER_SECOND;
+    long nanosAdjustment = (millis % MILLISECONDS_PER_SECOND) * NANOS_PER_MILLISECOND;
     return ofSeconds(seconds, nanosAdjustment);
   }
 
@@ -175,5 +183,25 @@ public final class Duration implements Comparable<Duration> {
   public String toString() {
     // TODO ISO format would be nicer.
     return "Duration{seconds=" + seconds + ", nanosOfSecond=" + nanosOfSecond + "}";
+  }
+
+  /**
+   * Converts a {@link java.time.Duration} to a {@link Duration}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  public static Duration ofJavaTime(java.time.Duration duration) {
+    return Duration.ofNanos(duration.toNanos());
+  }
+
+  /**
+   * Converts a {@link Duration} to a {@link java.time.Duration}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  public java.time.Duration toJavaTime() {
+    return java.time.Duration.ofNanos(toNanos());
   }
 }

--- a/android/java/com/google/time/client/base/Instant.java
+++ b/android/java/com/google/time/client/base/Instant.java
@@ -21,6 +21,8 @@ import static com.google.time.client.base.impl.DateTimeConstants.MILLISECONDS_PE
 import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_MILLISECOND;
 import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_SECOND;
 
+import android.os.Build;
+import androidx.annotation.RequiresApi;
 import com.google.time.client.base.impl.ExactMath;
 import com.google.time.client.base.impl.Objects;
 
@@ -138,5 +140,25 @@ public final class Instant implements Comparable<Instant> {
       throw new DateTimeException("seconds is out of allowed range");
     }
     return seconds;
+  }
+
+  /**
+   * Converts an {@link java.time.Instant} to an {@link Instant}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  public static Instant ofJavaTime(java.time.Instant javaTimeInstant) {
+    return Instant.ofEpochSecond(javaTimeInstant.getEpochSecond(), javaTimeInstant.getNano());
+  }
+
+  /**
+   * Converts an {@link Instant} to an {@link java.time.Instant}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  @RequiresApi(Build.VERSION_CODES.O)
+  public java.time.Instant toJavaTime() {
+    return java.time.Instant.ofEpochSecond(getEpochSecond(), getNano());
   }
 }

--- a/android/java/com/google/time/client/base/testing/TestEnvironmentUtils.java
+++ b/android/java/com/google/time/client/base/testing/TestEnvironmentUtils.java
@@ -50,6 +50,14 @@ public class TestEnvironmentUtils {
   }
 
   /**
+   * Returns the Android API level when the test is running the Android variant of code. Throws
+   * {@link AssertionError} when on Java SE.
+   */
+  public static int getAndroidApiLevel() {
+    return Build.VERSION.SDK_INT;
+  }
+
+  /**
    * Throws {@link org.junit.AssumptionViolatedException} if running the Android variant of code
    * under robolectric.
    */
@@ -57,7 +65,10 @@ public class TestEnvironmentUtils {
     assumeFalse(reason, isThisRobolectric());
   }
 
-  private static boolean isThisRobolectric() {
+  /**
+   * Returns {@code true if running the Android variant of code under robolectric.
+   */
+  public static boolean isThisRobolectric() {
     // "robolectric" may also be acceptable.
     return Objects.equals(null, Build.FINGERPRINT);
   }

--- a/common/java/com/google/time/client/base/Network.java
+++ b/common/java/com/google/time/client/base/Network.java
@@ -30,7 +30,7 @@ public interface Network {
 
   InetAddress[] getAllByName(String hostString) throws UnknownHostException;
 
-  UdpSocket createUdpSocket() throws SocketException;
+  UdpSocket createUdpSocket() throws IOException;
 
   /** A partial interface over {@link java.net.DatagramSocket} to make it easier to test with. */
   interface UdpSocket extends AutoCloseable {

--- a/common/java/com/google/time/client/sntp/BasicSntpClient.java
+++ b/common/java/com/google/time/client/sntp/BasicSntpClient.java
@@ -27,10 +27,12 @@ import com.google.time.client.base.ServerAddress;
 import com.google.time.client.base.Ticker;
 import com.google.time.client.base.annotations.VisibleForTesting;
 import com.google.time.client.base.impl.Objects;
+import com.google.time.client.base.impl.PlatformRandom;
 import com.google.time.client.base.impl.SystemStreamLogger;
 import com.google.time.client.sntp.impl.SntpClientEngine;
 import com.google.time.client.sntp.impl.SntpConnector;
 import com.google.time.client.sntp.impl.SntpConnectorImpl;
+import java.util.Random;
 
 /**
  * A simple implementation of {@link SntpClient} that is configured with a single server name. The
@@ -81,6 +83,7 @@ public final class BasicSntpClient implements SntpClient {
    *   <li>clientInstantSource - {@link PlatformInstantSource}
    *   <li>clientTicker - {@link PlatformTicker}
    *   <li>network - {@link PlatformNetwork}
+   *   <li>random - {@link PlatformRandom}
    * </ul>
    *
    * <p>Other properties must be set explicitly.
@@ -94,6 +97,7 @@ public final class BasicSntpClient implements SntpClient {
     private Ticker clientTicker = PlatformTicker.instance();
     private Network network = PlatformNetwork.instance();
     private boolean clientDataMinimizationEnabled = true;
+    private Random random = PlatformRandom.getDefaultRandom();
 
     // Properties without defaults.
     private ClientConfig clientConfig;
@@ -138,6 +142,12 @@ public final class BasicSntpClient implements SntpClient {
       return this;
     }
 
+    /** Sets the {@link Random} to use. Its exact use depends on the protocol / other settings. */
+    public Builder setRandom(Random random) {
+      this.random = Objects.requireNonNull(random);
+      return this;
+    }
+
     /** Sets the {@link ClientConfig config} to use. */
     public Builder setClientConfig(ClientConfig clientConfig) {
       this.clientConfig = Objects.requireNonNull(clientConfig);
@@ -152,7 +162,7 @@ public final class BasicSntpClient implements SntpClient {
       SntpConnector sntpConnector =
           new SntpConnectorImpl(
               logger, network, clientInstantSource, clientTicker, listener, clientConfig);
-      SntpClientEngine engine = new SntpClientEngine(logger, sntpConnector);
+      SntpClientEngine engine = new SntpClientEngine(logger, sntpConnector, random);
       engine.setClientDataMinimizationEnabled(clientDataMinimizationEnabled);
       return new BasicSntpClient(engine, clientInstantSource);
     }

--- a/common/java/com/google/time/client/sntp/impl/SntpConnectorImpl.java
+++ b/common/java/com/google/time/client/sntp/impl/SntpConnectorImpl.java
@@ -32,7 +32,6 @@ import com.google.time.client.sntp.SntpNetworkListener;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
-import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -167,7 +166,7 @@ public final class SntpConnectorImpl implements SntpConnector {
           // Capture T4 / [client]responseTimestamp according to the client's Ticker
           responseTimeTicks = clientTicker.ticks();
         }
-      } catch (SocketException e) {
+      } catch (IOException e) {
         // These indicate an inability to create or configure the outgoing socket.
         throw new NtpServerNotReachableException("Unable to create/configure UdpSocket", e);
       }

--- a/common/javatests/com/google/time/client/base/DurationTest.java
+++ b/common/javatests/com/google/time/client/base/DurationTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.google.time.client.base.testing.TestEnvironmentUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,8 +48,14 @@ public class DurationTest {
     assertEquals(0, constantZero.toNanos());
     assertNotNull(constantZero.toString());
 
-    Duration otherZero = Duration.ofNanos(0);
-    assertEqualityMethods(constantZero, otherZero);
+    {
+      Duration otherZero = Duration.ofNanos(0);
+      assertEqualityMethods(constantZero, otherZero);
+    }
+    {
+      Duration otherZero = Duration.ofMillis(0);
+      assertEqualityMethods(constantZero, otherZero);
+    }
   }
 
   // Covers ofSeconds(), toNanos(), getSeconds(), getNano()
@@ -75,7 +82,7 @@ public class DurationTest {
   @Test
   public void toMillisOverflowCases() {
     long maxMillis = Long.MAX_VALUE;
-    long maxMillisAsSeconds = maxMillis / 1000;
+    long maxMillisAsSeconds = maxMillis / MILLISECONDS_PER_SECOND;
     long maxNanoAdjustment = (maxMillis % MILLISECONDS_PER_SECOND) * NANOS_PER_MILLISECOND;
     {
       Duration duration = Duration.ofSeconds(maxMillisAsSeconds, 0);
@@ -111,7 +118,7 @@ public class DurationTest {
     }
 
     long minMillis = Long.MIN_VALUE;
-    long minMillisAsSeconds = minMillis / 1000;
+    long minMillisAsSeconds = minMillis / MILLISECONDS_PER_SECOND;
     long minNanoAdjustment = (minMillis % MILLISECONDS_PER_SECOND) * NANOS_PER_MILLISECOND;
     {
       Duration duration = Duration.ofSeconds(minMillisAsSeconds, 0);
@@ -158,8 +165,14 @@ public class DurationTest {
     assertEquals(NANOS_PER_SECOND, posOneSecond.toNanos());
     assertNotNull(posOneSecond.toString());
 
-    Duration otherPosOneSecond = Duration.ofNanos(1000000000);
-    assertEqualityMethods(posOneSecond, otherPosOneSecond);
+    {
+      Duration otherPosOneSecond = Duration.ofNanos(NANOS_PER_SECOND);
+      assertEqualityMethods(posOneSecond, otherPosOneSecond);
+    }
+    {
+      Duration otherPosOneSecond = Duration.ofMillis(MILLISECONDS_PER_SECOND);
+      assertEqualityMethods(posOneSecond, otherPosOneSecond);
+    }
   }
 
   @Test
@@ -176,8 +189,14 @@ public class DurationTest {
     assertEquals(-NANOS_PER_SECOND, negOneSecond.toNanos());
     assertNotNull(negOneSecond.toString());
 
-    Duration otherNegOneSecond = Duration.ofNanos(-1000000000);
-    assertEqualityMethods(negOneSecond, otherNegOneSecond);
+    {
+      Duration otherNegOneSecond = Duration.ofNanos(-1 * NANOS_PER_SECOND);
+      assertEqualityMethods(negOneSecond, otherNegOneSecond);
+    }
+    {
+      Duration otherNegOneSecond = Duration.ofMillis(-1 * MILLISECONDS_PER_SECOND);
+      assertEqualityMethods(negOneSecond, otherNegOneSecond);
+    }
   }
 
   @Test
@@ -196,6 +215,30 @@ public class DurationTest {
 
     Duration otherPosOneNano = Duration.ofNanos(1);
     assertEqualityMethods(posOneNano, otherPosOneNano);
+  }
+
+  @Test
+  public void positiveOneMilli() {
+    Duration posOneMilli = Duration.ofSeconds(0, NANOS_PER_MILLISECOND);
+    assertEquals(0, posOneMilli.getSeconds());
+    assertEquals(NANOS_PER_MILLISECOND, posOneMilli.getNano());
+    assertThrows(ArithmeticException.class, () -> posOneMilli.dividedBy(0));
+    assertEquals(posOneMilli, posOneMilli.plus(Duration.ZERO));
+    assertEquals(Duration.ofSeconds(0, 2 * NANOS_PER_MILLISECOND), posOneMilli.plus(posOneMilli));
+    assertEquals(posOneMilli, posOneMilli.minus(Duration.ZERO));
+    assertEquals(Duration.ZERO, posOneMilli.minus(posOneMilli));
+    assertEquals(1, posOneMilli.toMillis());
+    assertEquals(NANOS_PER_MILLISECOND, posOneMilli.toNanos());
+    assertNotNull(posOneMilli.toString());
+
+    {
+      Duration otherPosOneMilli = Duration.ofNanos(NANOS_PER_MILLISECOND);
+      assertEqualityMethods(posOneMilli, otherPosOneMilli);
+    }
+    {
+      Duration otherPosOneMilli = Duration.ofMillis(1);
+      assertEqualityMethods(posOneMilli, otherPosOneMilli);
+    }
   }
 
   @Test
@@ -222,6 +265,30 @@ public class DurationTest {
   }
 
   @Test
+  public void negativeOneMilli() {
+    Duration negOneMilli = Duration.ofSeconds(0, -1 * NANOS_PER_MILLISECOND);
+    assertEquals(-1, negOneMilli.getSeconds());
+    assertEquals(999000000L, negOneMilli.getNano());
+    assertThrows(ArithmeticException.class, () -> negOneMilli.dividedBy(0));
+    assertEquals(negOneMilli, negOneMilli.plus(Duration.ZERO));
+    assertEquals(Duration.ofSeconds(0, -2 * NANOS_PER_MILLISECOND), negOneMilli.plus(negOneMilli));
+    assertEquals(negOneMilli, negOneMilli.minus(Duration.ZERO));
+    assertEquals(Duration.ZERO, negOneMilli.minus(negOneMilli));
+    assertEquals(-1, negOneMilli.toMillis());
+    assertEquals(-1 * NANOS_PER_MILLISECOND, negOneMilli.toNanos());
+    assertNotNull(negOneMilli.toString());
+
+    {
+      Duration otherNegOneMilli = Duration.ofNanos(-1 * NANOS_PER_MILLISECOND);
+      assertEqualityMethods(negOneMilli, otherNegOneMilli);
+    }
+    {
+      Duration otherNegOneMilli = Duration.ofMillis(-1);
+      assertEqualityMethods(negOneMilli, otherNegOneMilli);
+    }
+  }
+
+  @Test
   public void positive999999999Nano() {
     Duration pos999999999Nano = Duration.ofSeconds(0, 999999999);
     assertEquals(0, pos999999999Nano.getSeconds());
@@ -237,6 +304,30 @@ public class DurationTest {
 
     Duration otherPos999999999Nano = Duration.ofNanos(999999999);
     assertEqualityMethods(pos999999999Nano, otherPos999999999Nano);
+  }
+
+  @Test
+  public void positive999Milli() {
+    Duration pos999Milli = Duration.ofSeconds(0, 999000000);
+    assertEquals(0, pos999Milli.getSeconds());
+    assertEquals(999000000, pos999Milli.getNano());
+    assertThrows(ArithmeticException.class, () -> pos999Milli.dividedBy(0));
+    assertEquals(pos999Milli, pos999Milli.plus(Duration.ZERO));
+    assertEquals(Duration.ofSeconds(1, 998000000), pos999Milli.plus(pos999Milli));
+    assertEquals(pos999Milli, pos999Milli.minus(Duration.ZERO));
+    assertEquals(Duration.ZERO, pos999Milli.minus(pos999Milli));
+    assertEquals(999, pos999Milli.toMillis());
+    assertEquals(999000000, pos999Milli.toNanos());
+    assertNotNull(pos999Milli.toString());
+
+    {
+      Duration otherPos999Milli = Duration.ofNanos(999000000);
+      assertEqualityMethods(pos999Milli, otherPos999Milli);
+    }
+    {
+      Duration otherPos999Milli = Duration.ofMillis(999);
+      assertEqualityMethods(pos999Milli, otherPos999Milli);
+    }
   }
 
   @Test
@@ -260,6 +351,30 @@ public class DurationTest {
 
     Duration otherNeg999999999Nano = Duration.ofNanos(-999999999);
     assertEqualityMethods(neg999999999Nano, otherNeg999999999Nano);
+  }
+
+  @Test
+  public void negative999Milli() {
+    Duration neg999Milli = Duration.ofSeconds(0, -999000000);
+    assertEquals(-1, neg999Milli.getSeconds());
+    assertEquals(NANOS_PER_MILLISECOND, neg999Milli.getNano());
+    assertThrows(ArithmeticException.class, () -> neg999Milli.dividedBy(0));
+    assertEquals(neg999Milli, neg999Milli.plus(Duration.ZERO));
+    assertEquals(Duration.ofSeconds(-2, 2000000), neg999Milli.plus(neg999Milli));
+    assertEquals(neg999Milli, neg999Milli.minus(Duration.ZERO));
+    assertEquals(Duration.ZERO, neg999Milli.minus(neg999Milli));
+    assertEquals(-999, neg999Milli.toMillis());
+    assertEquals(-999000000, neg999Milli.toNanos());
+    assertNotNull(neg999Milli.toString());
+
+    {
+      Duration otherNeg999Milli = Duration.ofNanos(-999000000);
+      assertEqualityMethods(neg999Milli, otherNeg999Milli);
+    }
+    {
+      Duration otherNeg999Milli = Duration.ofMillis(-999);
+      assertEqualityMethods(neg999Milli, otherNeg999Milli);
+    }
   }
 
   // Covers ofNanos(), getSeconds(), getNanos(), toMillis(), toNanos().
@@ -290,14 +405,12 @@ public class DurationTest {
       } else {
         assertEquals(0, duration.toMillis());
       }
-      assertEquals(-1L, duration.toNanos());
+      assertEquals(-1, duration.toNanos());
     }
 
     {
       int nanos = -(NANOS_PER_MILLISECOND - 1);
       Duration duration = Duration.ofNanos(nanos);
-      // -1 on OpenJDK 8, 0 on OpenJDK 9+, Android variant returns -1.
-      assertThat(duration.toMillis()).isAnyOf(0L, -1L);
       assertEquals(-1, duration.getSeconds());
       assertEquals(NANOS_PER_SECOND + nanos, duration.getNano());
       if (isThisAndroid() || (isThisJavaSe() && getJavaVersion() < 9)) {
@@ -311,7 +424,6 @@ public class DurationTest {
     {
       int nanos = NANOS_PER_MILLISECOND - 1;
       Duration duration = Duration.ofNanos(nanos);
-      assertEquals(0, duration.toMillis());
       assertEquals(0, duration.getSeconds());
       assertEquals(nanos, duration.getNano());
       assertEquals(0, duration.toMillis());
@@ -339,6 +451,74 @@ public class DurationTest {
       assertEquals(nanos % NANOS_PER_SECOND, duration.getNano());
       assertEquals(nanos / NANOS_PER_MILLISECOND, duration.toMillis());
       assertEquals(nanos, duration.toNanos());
+    }
+  }
+
+  // Covers ofMillis(), getSeconds(), getNanos(), toMillis(), toNanos().
+  @Test
+  public void ofMillis() {
+    {
+      Duration duration = Duration.ofMillis(0);
+      assertEquals(0, duration.getSeconds());
+      assertEquals(0, duration.getNano());
+      assertEquals(0, duration.toMillis());
+      assertEquals(0, duration.toNanos());
+    }
+
+    {
+      Duration duration = Duration.ofMillis(1);
+      assertEquals(0, duration.getSeconds());
+      assertEquals(NANOS_PER_MILLISECOND, duration.getNano());
+      assertEquals(1, duration.toMillis());
+      assertEquals(NANOS_PER_MILLISECOND, duration.toNanos());
+    }
+
+    {
+      Duration duration = Duration.ofMillis(-1);
+      assertEquals(-1, duration.getSeconds());
+      assertEquals(999000000, duration.getNano());
+      assertEquals(-1, duration.toMillis());
+      assertEquals(-1 * NANOS_PER_MILLISECOND, duration.toNanos());
+    }
+
+    {
+      int millis = -(MILLISECONDS_PER_SECOND - 1);
+      Duration duration = Duration.ofMillis(millis);
+      assertEquals(-1, duration.getSeconds());
+      assertEquals(NANOS_PER_MILLISECOND, duration.getNano());
+      assertEquals(millis, duration.toMillis());
+      assertEquals(-999000000, duration.toNanos());
+    }
+
+    {
+      int millis = MILLISECONDS_PER_SECOND - 1;
+      Duration duration = Duration.ofMillis(millis);
+      assertEquals(0, duration.getSeconds());
+      assertEquals(999000000, duration.getNano());
+      assertEquals(millis, duration.toMillis());
+      assertEquals(999000000, duration.toNanos());
+    }
+
+    {
+      long millis = Long.MIN_VALUE;
+      Duration duration = Duration.ofMillis(millis);
+      assertEquals((millis / MILLISECONDS_PER_SECOND) - 1, duration.getSeconds());
+      assertEquals(
+          (MILLISECONDS_PER_SECOND + (millis % MILLISECONDS_PER_SECOND)) * NANOS_PER_MILLISECOND,
+          duration.getNano());
+      if (isThisAndroid() || (isThisJavaSe() && getJavaVersion() < 9)) {
+        assertThrows(ArithmeticException.class, duration::toMillis);
+      } else {
+        assertEquals(millis, duration.toMillis());
+      }
+    }
+
+    {
+      long millis = Long.MAX_VALUE;
+      Duration duration = Duration.ofMillis(millis);
+      assertEquals(millis / MILLISECONDS_PER_SECOND, duration.getSeconds());
+      assertEquals((millis % MILLISECONDS_PER_SECOND) * NANOS_PER_MILLISECOND, duration.getNano());
+      assertEquals(millis, duration.toMillis());
     }
   }
 
@@ -712,6 +892,22 @@ public class DurationTest {
 
     if (seconds < Long.MAX_VALUE) {
       assertInequalityGreaterThan(Duration.ofSeconds(seconds + 1, 0), maxNano);
+    }
+  }
+
+  @Test
+  public void javaTimeInterop() {
+    long nanos = 1234567890123L;
+    // Avoid linkage errors.
+    if (TestEnvironmentUtils.isThisJavaSe()
+        || TestEnvironmentUtils.getAndroidApiLevel() >= 26
+        || TestEnvironmentUtils.isThisRobolectric()) {
+      assertEquals(java.time.Duration.ofNanos(nanos), Duration.ofNanos(nanos).toJavaTime());
+      assertEquals(Duration.ofNanos(nanos), Duration.ofJavaTime(java.time.Duration.ofNanos(nanos)));
+    } else {
+      assertThrows(NoClassDefFoundError.class, () -> Duration.ofNanos(nanos).toJavaTime());
+      assertThrows(
+          NoClassDefFoundError.class, () -> Duration.ofJavaTime(java.time.Duration.ofNanos(nanos)));
     }
   }
 

--- a/common/javatests/com/google/time/client/base/InstantTest.java
+++ b/common/javatests/com/google/time/client/base/InstantTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.google.time.client.base.testing.TestEnvironmentUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -413,6 +414,27 @@ public class InstantTest {
 
     if (seconds < Instant.MAX.getEpochSecond()) {
       assertInequalityGreaterThan(Instant.ofEpochSecond(seconds + 1, 0), maxNano);
+    }
+  }
+
+  @Test
+  public void javaTimeInterop() {
+    long epochMilli = 1234567890L;
+    // Avoid linkage errors.
+    if (TestEnvironmentUtils.isThisJavaSe()
+        || TestEnvironmentUtils.getAndroidApiLevel() >= 26
+        || TestEnvironmentUtils.isThisRobolectric()) {
+      assertEquals(
+          java.time.Instant.ofEpochMilli(epochMilli),
+          Instant.ofEpochMilli(epochMilli).toJavaTime());
+      assertEquals(
+          Instant.ofEpochMilli(epochMilli),
+          Instant.ofJavaTime(java.time.Instant.ofEpochMilli(epochMilli)));
+    } else {
+      assertThrows(NoClassDefFoundError.class, () -> Instant.ofEpochMilli(epochMilli).toJavaTime());
+      assertThrows(
+          NoClassDefFoundError.class,
+          () -> Instant.ofJavaTime(java.time.Instant.ofEpochMilli(epochMilli)));
     }
   }
 

--- a/javase/java/com/google/time/client/base/Duration.java
+++ b/javase/java/com/google/time/client/base/Duration.java
@@ -35,6 +35,10 @@ public final class Duration implements Comparable<Duration> {
     return new Duration(java.time.Duration.ofNanos(nanos));
   }
 
+  public static Duration ofMillis(long millis) {
+    return new Duration(java.time.Duration.ofMillis(millis));
+  }
+
   public static Duration ofSeconds(long seconds, long nanoAdjustment) {
     return new Duration(java.time.Duration.ofSeconds(seconds, nanoAdjustment));
   }
@@ -107,5 +111,23 @@ public final class Duration implements Comparable<Duration> {
   @Override
   public String toString() {
     return delegate.toString();
+  }
+
+  /**
+   * Converts a {@link java.time.Duration} to a {@link Duration}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  public static Duration ofJavaTime(java.time.Duration duration) {
+    return Duration.ofNanos(duration.toNanos());
+  }
+
+  /**
+   * Converts a {@link Duration} to a {@link java.time.Duration}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  public java.time.Duration toJavaTime() {
+    return java.time.Duration.ofNanos(toNanos());
   }
 }

--- a/javase/java/com/google/time/client/base/Instant.java
+++ b/javase/java/com/google/time/client/base/Instant.java
@@ -101,4 +101,22 @@ public final class Instant implements Comparable<Instant> {
   public String toString() {
     return delegate.toString();
   }
+
+  /**
+   * Converts an {@link java.time.Instant} to an {@link Instant}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  public static Instant ofJavaTime(java.time.Instant javaTimeInstant) {
+    return Instant.ofEpochSecond(javaTimeInstant.getEpochSecond(), javaTimeInstant.getNano());
+  }
+
+  /**
+   * Converts an {@link Instant} to an {@link java.time.Instant}.
+   *
+   * <p>Interoperability with {@code java.time} classes for platforms that support it.
+   */
+  public java.time.Instant toJavaTime() {
+    return java.time.Instant.ofEpochSecond(getEpochSecond(), getNano());
+  }
 }

--- a/javase/java/com/google/time/client/base/testing/TestEnvironmentUtils.java
+++ b/javase/java/com/google/time/client/base/testing/TestEnvironmentUtils.java
@@ -50,10 +50,26 @@ public final class TestEnvironmentUtils {
   }
 
   /**
+   * Returns the Android API level when the test is running the Android variant of code. Throws
+   * {@link AssertionError} when on Java SE.
+   */
+  public static int getAndroidApiLevel() {
+    throw new AssertionError("This is the Java SE variant");
+  }
+
+  /**
    * Throws {@link org.junit.AssumptionViolatedException} if running the Android variant of code
    * under robolectric.
    */
   public static void assumeNotRobolectric(String reason) {
     // This is the javase variant of this class, so by definition this assumption holds true.
+  }
+
+  /**
+   * Returns {@code true if running the Android variant of code under robolectric.
+   */
+  public static boolean isThisRobolectric() {
+    // This is the javase variant of this class, so by definition this is false.
+    return false;
   }
 }


### PR DESCRIPTION
Changes for observations made during a trial project import into the
Android platform:

1) Added java.time interoperability for the work-alike Duration /
   Instant types (platform can use java.time). Marked as @RequiredApi in
   the Android variant, which required androidx.annotation, and the
   compile API level used by bazel has been moved up to 26. This should
   mean its ok for folks targeting < 26, and their tools will steer them
   clear of the affected methods.

2) Addition of Duration.ofMillis() as it's useful for testing.

3) Switch Network to throwing IOException for one method instead of
   SocketException, as Android's network.bindSocket() method throws
   IOException and there isn't a lot of value in wrapping it.

4) Make the Random configurable on BasicSntpClient.

5) Some more support for test environment detection, i.e. for
   robolectric and Android API.