### PR TITLE
Add errorprone suppressions for newer API refs

### DIFF
--- a/android/java/com/google/time/client/base/Duration.java
+++ b/android/java/com/google/time/client/base/Duration.java
@@ -190,6 +190,7 @@ public final class Duration implements Comparable<Duration> {
    *
    * <p>Interoperability with {@code java.time} classes for platforms that support it.
    */
+  @SuppressWarnings("AndroidJdkLibsChecker")
   @RequiresApi(Build.VERSION_CODES.O)
   public static Duration ofJavaTime(java.time.Duration duration) {
     return Duration.ofNanos(duration.toNanos());
@@ -200,6 +201,7 @@ public final class Duration implements Comparable<Duration> {
    *
    * <p>Interoperability with {@code java.time} classes for platforms that support it.
    */
+  @SuppressWarnings("AndroidJdkLibsChecker")
   @RequiresApi(Build.VERSION_CODES.O)
   public java.time.Duration toJavaTime() {
     return java.time.Duration.ofNanos(toNanos());

--- a/android/java/com/google/time/client/base/Instant.java
+++ b/android/java/com/google/time/client/base/Instant.java
@@ -147,6 +147,7 @@ public final class Instant implements Comparable<Instant> {
    *
    * <p>Interoperability with {@code java.time} classes for platforms that support it.
    */
+  @SuppressWarnings("AndroidJdkLibsChecker")
   @RequiresApi(Build.VERSION_CODES.O)
   public static Instant ofJavaTime(java.time.Instant javaTimeInstant) {
     return Instant.ofEpochSecond(javaTimeInstant.getEpochSecond(), javaTimeInstant.getNano());
@@ -157,6 +158,7 @@ public final class Instant implements Comparable<Instant> {
    *
    * <p>Interoperability with {@code java.time} classes for platforms that support it.
    */
+  @SuppressWarnings("AndroidJdkLibsChecker")
   @RequiresApi(Build.VERSION_CODES.O)
   public java.time.Instant toJavaTime() {
     return java.time.Instant.ofEpochSecond(getEpochSecond(), getNano());


### PR DESCRIPTION
Google tooling picks up on the use of newer java.time APIs only present
from API 26. I've not found a way to make the tooling aware that this is
ok: The methods are clearly marked as @RequiresApi and so should not be
used (and, I assume, won't cause an issue at runtime unless the method
is resolved in preparation for a call), so I think suppressing these
warnings should be safe and should consistitute a no-op outside of
Google.