### PR TITLE
Reduce the severity of unusual / unexpected timeout behavior

### DIFF
--- a/common/java/com/google/time/client/sntp/impl/SntpClientEngine.java
+++ b/common/java/com/google/time/client/sntp/impl/SntpClientEngine.java
@@ -57,7 +57,7 @@ public class SntpClientEngine {
         new SntpQueryOperation(
             logger, network, instantSource, ticker, clientConfig, requestSupplier);
     ClusteredServiceOperation<Void, SuccessResult, FailureResult> networkServiceConnector =
-        new ClusteredServiceOperation<>(ticker, network, sntpQueryOperation);
+        new ClusteredServiceOperation<>(logger, ticker, network, sntpQueryOperation);
     SntpServiceConnectorImpl sntpServiceConnector =
         new SntpServiceConnectorImpl(clientConfig, networkServiceConnector);
     return new SntpClientEngine(logger, sntpServiceConnector);

--- a/common/java/com/google/time/client/sntp/testing/TestSntpServerWithNetwork.java
+++ b/common/java/com/google/time/client/sntp/testing/TestSntpServerWithNetwork.java
@@ -139,16 +139,12 @@ public final class TestSntpServerWithNetwork<E extends TestSntpServerEngine, N e
     Random random = new PredictableRandom();
     Supplier<NtpMessage> requestFactory =
         new SntpRequestFactory(clientInstantSource, random, 3, true);
+    NoOpLogger logger = NoOpLogger.instance();
     SntpQueryOperation sntpQueryOperation =
         new SntpQueryOperation(
-            NoOpLogger.instance(),
-            network,
-            clientInstantSource,
-            clientTicker,
-            clientConfig,
-            requestFactory);
+            logger, network, clientInstantSource, clientTicker, clientConfig, requestFactory);
     ClusteredServiceOperation<Void, SuccessResult, FailureResult> networkServiceConnector =
-        new ClusteredServiceOperation<>(clientTicker, network, sntpQueryOperation);
+        new ClusteredServiceOperation<>(logger, clientTicker, network, sntpQueryOperation);
     return new SntpServiceConnectorImpl(clientConfig, networkServiceConnector);
   }
 


### PR DESCRIPTION
Before this commit, ClusteredServiceOperation treats the following scenario as a fatal error (IllegalStateException):

1) Clustered operation has N seconds to execute and passes that to the
   service operation.
2) Service operation says reports it ran out of time in < N seconds.

In the SNTP implementation, it looks like this can happen when the SntpClientOperation is given less time to complete than it would usually wait for a UDP response, e.g. if it would usually wait 5 seconds for a response but it is only given 3 seconds. In these cases, rather than setting a socket timeout of 5 seconds, it sets 3 seconds and relies on the DatagramSocket, and ultimately its implementation and maybe even the kernel to enforce this timeout. When a SocketTimeoutException is thrown it reports this as "allowed time exceeded".

What appears to be possible is that the SocketTimeoutException can be thrown "early", triggering the ClusteredServiceOperation IllegalStateException. Speculating, this might be due to a different clock being used or (most likely, based on prior, hazily remembered, experience), the HZ kernel setting in Linux, which I believe can cause timeouts to trigger early.

In any case, treating this case as fatal is causing problems in some environments / scenarios, so this commit reduces the severity to just logging and pretending the socket timeout worked as intended.