### PR TITLE
Make FakeClocks Ticker implement AndroidTicker

### DIFF
--- a/android/java/com/google/time/client/base/testing/FakeInstantSource.java
+++ b/android/java/com/google/time/client/base/testing/FakeInstantSource.java
@@ -1,0 +1,1 @@
+../../../../../../../../common/java/com/google/time/client/base/testing/FakeInstantSource.java

--- a/android/java/com/google/time/client/base/testing/FakeTicker.java
+++ b/android/java/com/google/time/client/base/testing/FakeTicker.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.time.client.base.testing;
+
+import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_MILLISECOND;
+import static org.junit.Assert.assertEquals;
+
+import com.google.time.client.base.AndroidTicker;
+import com.google.time.client.base.Duration;
+import com.google.time.client.base.Ticker;
+import com.google.time.client.base.Ticks;
+import com.google.time.client.base.impl.ExactMath;
+import com.google.time.client.base.impl.Objects;
+
+/**
+ * A fake {@link Ticker} that can be used for tests. See {@link FakeClocks} for how to obtain an
+ * instance. This ticker simulates one that increments the tick value every nanosecond.
+ */
+public final class FakeTicker extends AndroidTicker implements Advanceable {
+
+  private final FakeClocks fakeClocks;
+
+  private long ticksValue;
+
+  FakeTicker(FakeClocks fakeClocks) {
+    this.fakeClocks = Objects.requireNonNull(fakeClocks);
+  }
+
+  @Override
+  public Duration durationBetween(Ticks start, Ticks end) throws IllegalArgumentException {
+    return Duration.ofNanos(incrementsBetween(start, end));
+  }
+
+  @Override
+  public Ticks ticks() {
+    ticksValue += fakeClocks.autoAdvanceDuration.toNanos();
+    return getCurrentTicks();
+  }
+
+  @Override
+  public Ticks ticksForElapsedRealtimeNanos(long elapsedRealtimeNanos) {
+    return ticksForValue(elapsedRealtimeNanos);
+  }
+
+  @Override
+  public Ticks ticksForElapsedRealtimeMillis(long elapsedRealtimeMillis) {
+    long elapsedRealtimeNanos =
+        ExactMath.multiplyExact(elapsedRealtimeMillis, NANOS_PER_MILLISECOND);
+    return createTicks(elapsedRealtimeNanos);
+  }
+
+  @Override
+  public long elapsedRealtimeNanosForTicks(Ticks ticks) {
+    checkThisIsTicksOrigin(ticks);
+    return valueForTicks(ticks);
+  }
+
+  @Override
+  public long elapsedRealtimeMillisForTicks(Ticks ticks) {
+    checkThisIsTicksOrigin(ticks);
+    return valueForTicks(ticks) / NANOS_PER_MILLISECOND;
+  }
+
+  /** Asserts the current ticks value matches the one supplied. Does not auto advance. */
+  public void assertCurrentTicks(Ticks actual) {
+    assertEquals(createTicks(ticksValue), actual);
+  }
+
+  /** Returns the current ticks value. Does not auto advance. */
+  public Ticks getCurrentTicks() {
+    return createTicks(ticksValue);
+  }
+
+  /** Returns a ticks value. Does not auto advance. */
+  public Ticks ticksForValue(long value) {
+    return createTicks(value);
+  }
+
+  /** Sets the current ticks value. Does not auto advance. */
+  public void setTicksValue(long ticksValue) {
+    this.ticksValue = ticksValue;
+  }
+
+  public void advanceNanos(long nanos) {
+    // FakeTicker.ticksValue is fixed to nanoseconds.
+    ticksValue += nanos;
+  }
+
+  @Override
+  public void advance(Duration duration) {
+    advanceNanos(duration.toNanos());
+  }
+
+  @Override
+  public String toString() {
+    return "FakeTicker{"
+        + "ticksValue="
+        + ticksValue
+        + ", fakeClocks.autoAdvanceDuration="
+        + fakeClocks.autoAdvanceDuration
+        + '}';
+  }
+}

--- a/android/javatests/com/google/time/client/base/PlatformTickerTest.java
+++ b/android/javatests/com/google/time/client/base/PlatformTickerTest.java
@@ -83,14 +83,15 @@ public class PlatformTickerTest {
     {
       long elapsedRealtimeNanos = 1234567890123L;
       Ticks nanoTicks = ticker.ticksForElapsedRealtimeNanos(elapsedRealtimeNanos);
-      assertEquals(elapsedRealtimeNanos, nanoTicks.getValue());
+      assertEquals(elapsedRealtimeNanos, ticker.valueForTicks(nanoTicks));
       assertEquals(elapsedRealtimeNanos, ticker.elapsedRealtimeNanosForTicks(nanoTicks));
     }
 
     {
       long elapsedRealtimeMillis = 1234567890L;
       Ticks millisTicks = ticker.ticksForElapsedRealtimeMillis(elapsedRealtimeMillis);
-      assertEquals(elapsedRealtimeMillis * NANOS_PER_MILLISECOND, millisTicks.getValue());
+      assertEquals(
+          elapsedRealtimeMillis * NANOS_PER_MILLISECOND, ticker.valueForTicks(millisTicks));
       assertEquals(elapsedRealtimeMillis, ticker.elapsedRealtimeMillisForTicks(millisTicks));
     }
   }

--- a/android/javatests/com/google/time/client/base/testing/FakeTickerTest.java
+++ b/android/javatests/com/google/time/client/base/testing/FakeTickerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.time.client.base.testing;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.time.client.base.AndroidTicker;
+import com.google.time.client.base.Ticks;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class FakeTickerTest {
+
+  @Test
+  public void implementsAndroidTicker() {
+    FakeClocks fakeClocks = new FakeClocks();
+    AndroidTicker fakeTicker = fakeClocks.getFakeTicker();
+    {
+      long elapsedRealtimeMillis = 1234;
+      Ticks ticks = fakeTicker.ticksForElapsedRealtimeMillis(elapsedRealtimeMillis);
+      assertEquals(elapsedRealtimeMillis, fakeTicker.elapsedRealtimeMillisForTicks(ticks));
+    }
+    {
+      long elapsedRealtimeNanos = 1234;
+      Ticks ticks = fakeTicker.ticksForElapsedRealtimeNanos(elapsedRealtimeNanos);
+      assertEquals(elapsedRealtimeNanos, fakeTicker.elapsedRealtimeNanosForTicks(ticks));
+    }
+  }
+}

--- a/common/java/com/google/time/client/base/Ticker.java
+++ b/common/java/com/google/time/client/base/Ticker.java
@@ -85,4 +85,10 @@ public abstract class Ticker {
   protected final Ticks createTicks(long value) {
     return Ticks.fromTickerValue(this, value);
   }
+
+  /** Extract the value from a {@link Ticks} created by this ticker. */
+  protected final long valueForTicks(Ticks ticks) {
+    checkThisIsTicksOrigin(ticks);
+    return ticks.getValue();
+  }
 }

--- a/common/java/com/google/time/client/base/testing/FakeClocks.java
+++ b/common/java/com/google/time/client/base/testing/FakeClocks.java
@@ -15,15 +15,9 @@
  */
 package com.google.time.client.base.testing;
 
-import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_MILLISECOND;
-import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_SECOND;
-import static org.junit.Assert.assertEquals;
-
 import com.google.time.client.base.Duration;
-import com.google.time.client.base.Instant;
 import com.google.time.client.base.InstantSource;
 import com.google.time.client.base.Ticker;
-import com.google.time.client.base.Ticks;
 
 /**
  * A source of fake {@link Ticker} and {@link InstantSource} objects that can be made to advance
@@ -32,10 +26,10 @@ import com.google.time.client.base.Ticks;
  */
 public final class FakeClocks implements Advanceable {
 
-  private final FakeInstantSource fakeInstantSource = new FakeInstantSource();
-  private final FakeTicker fakeTicker = new FakeTicker();
+  private final FakeInstantSource fakeInstantSource = new FakeInstantSource(this);
+  private final FakeTicker fakeTicker = new FakeTicker(this);
 
-  private Duration autoAdvanceDuration = Duration.ZERO;
+  Duration autoAdvanceDuration = Duration.ZERO;
 
   /** Clock is automatically advanced <em>before</em> the time is read. */
   public void setAutoAdvanceNanos(long autoAdvanceNanos) {
@@ -61,147 +55,5 @@ public final class FakeClocks implements Advanceable {
   public void advance(Duration duration) {
     fakeInstantSource.advance(duration);
     fakeTicker.advance(duration);
-  }
-
-  /**
-   * A fake {@link Ticker} that can be used for tests. This ticker simulates one that increments the
-   * tick value every nanosecond.
-   */
-  public final class FakeTicker extends Ticker implements Advanceable {
-
-    private long ticksValue;
-
-    private FakeTicker() {}
-
-    @Override
-    public Duration durationBetween(Ticks start, Ticks end) throws IllegalArgumentException {
-      return Duration.ofNanos(incrementsBetween(start, end));
-    }
-
-    @Override
-    public Ticks ticks() {
-      ticksValue += autoAdvanceDuration.toNanos();
-      return getCurrentTicks();
-    }
-
-    /** Asserts the current ticks value matches the one supplied. Does not auto advance. */
-    public void assertCurrentTicks(Ticks actual) {
-      assertEquals(createTicks(ticksValue), actual);
-    }
-
-    /** Returns the current ticks value. Does not auto advance. */
-    public Ticks getCurrentTicks() {
-      return createTicks(ticksValue);
-    }
-
-    /** Returns a ticks value. Does not auto advance. */
-    public Ticks ticksForValue(int value) {
-      return createTicks(value);
-    }
-
-    /** Sets the current ticks value. Does not auto advance. */
-    public void setTicksValue(long ticksValue) {
-      this.ticksValue = ticksValue;
-    }
-
-    public void advanceNanos(long nanos) {
-      // FakeTicker.ticksValue is fixed to nanoseconds.
-      ticksValue += nanos;
-    }
-
-    @Override
-    public void advance(Duration duration) {
-      advanceNanos(duration.toNanos());
-    }
-
-    @Override
-    public String toString() {
-      return "FakeTicker{"
-          + "ticksValue="
-          + ticksValue
-          + ", FakeClocks.this.autoAdvanceDuration="
-          + FakeClocks.this.autoAdvanceDuration
-          + '}';
-    }
-  }
-
-  /**
-   * A fake {@link InstantSource} that can be used for tests.
-   *
-   * <p>By default, this instant source simulates one that returns instants with millisecond
-   * precision, but this can be changed.
-   */
-  public final class FakeInstantSource extends InstantSource implements Advanceable {
-
-    private Instant instantSourceNow = Instant.ofEpochMilli(0);
-    private int precision = InstantSource.PRECISION_MILLIS;
-
-    private FakeInstantSource() {}
-
-    @Override
-    public int getPrecision() {
-      return precision;
-    }
-
-    @Override
-    public Instant instant() {
-      instantSourceNow = instantSourceNow.plus(autoAdvanceDuration);
-      if (precision == PRECISION_MILLIS) {
-        return Instant.ofEpochMilli(instantSourceNow.toEpochMilli());
-      } else if (precision == PRECISION_NANOS) {
-        return instantSourceNow;
-      }
-      throw new IllegalStateException("Unknown resolution=" + precision);
-    }
-
-    /** Advance this instant source by the specified number of milliseconds. */
-    public void advanceMillis(long millis) {
-      advance(Duration.ofNanos(millis * NANOS_PER_MILLISECOND));
-    }
-
-    /** Advance this instant source by the specified duration. */
-    @Override
-    public void advance(Duration duration) {
-      instantSourceNow = instantSourceNow.plus(duration);
-    }
-
-    public void setEpochMillis(long epochMillis) {
-      instantSourceNow = Instant.ofEpochMilli(epochMillis);
-    }
-
-    public void setInstant(Instant instant) {
-      instantSourceNow = instant;
-    }
-
-    /** Returns the current instant. Does not auto advance. */
-    public Instant getCurrentInstant() {
-      return instantSourceNow;
-    }
-
-    public void setPrecision(int precision) {
-      this.precision = precision;
-    }
-
-    public void setEpochNanos(long epochNanos) {
-      long seconds = epochNanos / NANOS_PER_SECOND;
-      long nanos = epochNanos % NANOS_PER_SECOND;
-      if (epochNanos < 0) {
-        seconds--;
-        nanos += NANOS_PER_SECOND;
-      }
-      instantSourceNow = Instant.ofEpochSecond(seconds, nanos);
-    }
-
-    @Override
-    public String toString() {
-      return "FakeInstantSource{"
-          + "instantSourceNow="
-          + instantSourceNow
-          + ", resolution="
-          + precision
-          + ", FakeClocks.this.autoAdvanceDuration="
-          + FakeClocks.this.autoAdvanceDuration
-          + '}';
-    }
   }
 }

--- a/common/java/com/google/time/client/base/testing/FakeInstantSource.java
+++ b/common/java/com/google/time/client/base/testing/FakeInstantSource.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.time.client.base.testing;
+
+import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_MILLISECOND;
+import static com.google.time.client.base.impl.DateTimeConstants.NANOS_PER_SECOND;
+
+import com.google.time.client.base.Duration;
+import com.google.time.client.base.Instant;
+import com.google.time.client.base.InstantSource;
+import com.google.time.client.base.impl.Objects;
+
+/**
+ * A fake {@link InstantSource} that can be used for tests. See {@link FakeClocks} for how to obtain
+ * an instance.
+ *
+ * <p>By default, this instant source simulates one that returns instants with millisecond
+ * precision, but this can be changed.
+ */
+public final class FakeInstantSource extends InstantSource implements Advanceable {
+
+  private Instant instantSourceNow = Instant.ofEpochMilli(0);
+  private int precision = InstantSource.PRECISION_MILLIS;
+
+  private final FakeClocks fakeClocks;
+
+  FakeInstantSource(FakeClocks fakeClocks) {
+    this.fakeClocks = Objects.requireNonNull(fakeClocks);
+  }
+
+  @Override
+  public int getPrecision() {
+    return precision;
+  }
+
+  @Override
+  public Instant instant() {
+    instantSourceNow = instantSourceNow.plus(fakeClocks.autoAdvanceDuration);
+    if (precision == PRECISION_MILLIS) {
+      return Instant.ofEpochMilli(instantSourceNow.toEpochMilli());
+    } else if (precision == PRECISION_NANOS) {
+      return instantSourceNow;
+    }
+    throw new IllegalStateException("Unknown resolution=" + precision);
+  }
+
+  /** Advance this instant source by the specified number of milliseconds. */
+  public void advanceMillis(long millis) {
+    advance(Duration.ofNanos(millis * NANOS_PER_MILLISECOND));
+  }
+
+  /** Advance this instant source by the specified duration. */
+  @Override
+  public void advance(Duration duration) {
+    instantSourceNow = instantSourceNow.plus(duration);
+  }
+
+  public void setEpochMillis(long epochMillis) {
+    instantSourceNow = Instant.ofEpochMilli(epochMillis);
+  }
+
+  public void setInstant(Instant instant) {
+    instantSourceNow = instant;
+  }
+
+  /** Returns the current instant. Does not auto advance. */
+  public Instant getCurrentInstant() {
+    return instantSourceNow;
+  }
+
+  public void setPrecision(int precision) {
+    this.precision = precision;
+  }
+
+  public void setEpochNanos(long epochNanos) {
+    long seconds = epochNanos / NANOS_PER_SECOND;
+    long nanos = epochNanos % NANOS_PER_SECOND;
+    if (epochNanos < 0) {
+      seconds--;
+      nanos += NANOS_PER_SECOND;
+    }
+    instantSourceNow = Instant.ofEpochSecond(seconds, nanos);
+  }
+
+  @Override
+  public String toString() {
+    return "FakeInstantSource{"
+        + "instantSourceNow="
+        + instantSourceNow
+        + ", resolution="
+        + precision
+        + ", fakeClocks.autoAdvanceDuration="
+        + fakeClocks.autoAdvanceDuration
+        + '}';
+  }
+}

--- a/common/java/com/google/time/client/sntp/testing/FakeNetwork.java
+++ b/common/java/com/google/time/client/sntp/testing/FakeNetwork.java
@@ -25,6 +25,7 @@ import com.google.time.client.base.Ticks;
 import com.google.time.client.base.impl.Objects;
 import com.google.time.client.base.testing.Advanceable;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeTicker;
 import com.google.time.client.sntp.impl.NtpMessage;
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -193,7 +194,7 @@ public final class FakeNetwork implements Network {
     @Override
     public void receive(DatagramPacket packet) throws IOException {
       // Handle the network send delay and process the packet in the engine.
-      FakeClocks.FakeTicker clientTicker = clientClocks.getFakeTicker();
+      FakeTicker clientTicker = clientClocks.getFakeTicker();
       Ticks receiveStartTicks = clientTicker.ticks();
       processNetworkPacket();
 

--- a/common/java/com/google/time/client/sntp/testing/FakeSntpServerEngine.java
+++ b/common/java/com/google/time/client/sntp/testing/FakeSntpServerEngine.java
@@ -21,7 +21,7 @@ import com.google.time.client.base.Instant;
 import com.google.time.client.base.impl.Objects;
 import com.google.time.client.base.impl.PlatformRandom;
 import com.google.time.client.base.testing.Advanceable;
-import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeInstantSource;
 import com.google.time.client.sntp.impl.NtpHeader;
 import com.google.time.client.sntp.impl.NtpMessage;
 import com.google.time.client.sntp.impl.Timestamp64;
@@ -39,7 +39,7 @@ public final class FakeSntpServerEngine implements TestSntpServerEngine {
   private final List<NtpMessage> requestsReceived = new ArrayList<>();
   private final List<NtpMessage> responsesSent = new ArrayList<>();
   private final List<Advanceable> advanceables = new ArrayList<>();
-  private final FakeClocks.FakeInstantSource instantSource;
+  private final FakeInstantSource instantSource;
 
   private Vector<NtpMessage> responseTemplates = new Vector<>();
 
@@ -49,7 +49,7 @@ public final class FakeSntpServerEngine implements TestSntpServerEngine {
   private Duration processingDuration = Duration.ZERO;
   private int quirkMode;
 
-  public FakeSntpServerEngine(FakeClocks.FakeInstantSource instantSource) {
+  public FakeSntpServerEngine(FakeInstantSource instantSource) {
     this.instantSource = Objects.requireNonNull(instantSource);
   }
 

--- a/common/javatests/com/google/time/client/base/TickerTest.java
+++ b/common/javatests/com/google/time/client/base/TickerTest.java
@@ -51,13 +51,13 @@ public class TickerTest {
   private static void doIncrementsBetweenTest(TestTicker ticker, long tickerValue, long increment) {
     Ticks t1 = ticker.forTickerValue(tickerValue);
     Ticks t2 = ticker.forTickerValue(ExactMath.addExact(tickerValue, increment));
-    if (willSubtractionOverflow(t2.getValue(), t1.getValue())) {
+    if (willSubtractionOverflow(ticker.valueForTicks(t2), ticker.valueForTicks(t1))) {
       fail("Bad test");
     } else {
       assertEquals(increment, ticker.incrementsBetween(t1, t2));
     }
 
-    if (willSubtractionOverflow(t1.getValue(), t2.getValue())) {
+    if (willSubtractionOverflow(ticker.valueForTicks(t1), ticker.valueForTicks(t2))) {
       fail("Bad test");
     } else {
       assertEquals(-increment, ticker.incrementsBetween(t2, t1));

--- a/common/javatests/com/google/time/client/base/impl/ClusteredServiceOperationTest.java
+++ b/common/javatests/com/google/time/client/base/impl/ClusteredServiceOperationTest.java
@@ -25,6 +25,7 @@ import com.google.time.client.base.Duration;
 import com.google.time.client.base.Network;
 import com.google.time.client.base.impl.ClusteredServiceOperation.ServiceOperation.ServiceResult;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeTicker;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -41,7 +42,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ClusteredServiceOperationTest {
 
-  private FakeClocks.FakeTicker fakeTicker;
+  private FakeTicker fakeTicker;
   private FakeNetwork fakeNetwork;
   private TestServiceOperation serviceOperation;
   private ClusteredServiceOperation<Parameter, Success, Failure> clusteredOperation;
@@ -363,9 +364,7 @@ public class ClusteredServiceOperationTest {
   }
 
   private static TestServiceOperation.Function alwaysFailsAndTakesTime(
-      FakeClocks.FakeTicker ticker,
-      Duration serviceTimeTaken,
-      boolean operationReportsTimeAllowedExceeded) {
+      FakeTicker ticker, Duration serviceTimeTaken, boolean operationReportsTimeAllowedExceeded) {
     return (ipAddress, param, timeAllowed) -> {
       if (operationReportsTimeAllowedExceeded && timeAllowed.compareTo(serviceTimeTaken) <= 0) {
         ticker.advance(timeAllowed);
@@ -378,7 +377,7 @@ public class ClusteredServiceOperationTest {
   }
 
   private static TestServiceOperation.Function takesTimeAndLiesAboutTimeout(
-      FakeClocks.FakeTicker ticker, Duration serviceTimeTaken) {
+      FakeTicker ticker, Duration serviceTimeTaken) {
     return (ipAddress, param, timeAllowed) -> {
       ticker.advance(serviceTimeTaken);
       return ServiceResult.timeAllowedExceeded(ipAddress);
@@ -389,9 +388,9 @@ public class ClusteredServiceOperationTest {
 
     private Map<String, InetAddress[]> fakeDns = new HashMap<>();
     private Duration fakeDnsLookupTimeTaken = Duration.ZERO;
-    private FakeClocks.FakeTicker fakeTicker;
+    private FakeTicker fakeTicker;
 
-    public FakeNetwork(FakeClocks.FakeTicker fakeTicker) {
+    public FakeNetwork(FakeTicker fakeTicker) {
       this.fakeTicker = Objects.requireNonNull(fakeTicker);
     }
 

--- a/common/javatests/com/google/time/client/base/testing/FakeClocksTest.java
+++ b/common/javatests/com/google/time/client/base/testing/FakeClocksTest.java
@@ -23,8 +23,6 @@ import com.google.time.client.base.Duration;
 import com.google.time.client.base.Instant;
 import com.google.time.client.base.InstantSource;
 import com.google.time.client.base.Ticks;
-import com.google.time.client.base.testing.FakeClocks.FakeInstantSource;
-import com.google.time.client.base.testing.FakeClocks.FakeTicker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/common/javatests/com/google/time/client/sntp/impl/SntpClientEngineNetworkingTest.java
+++ b/common/javatests/com/google/time/client/sntp/impl/SntpClientEngineNetworkingTest.java
@@ -32,6 +32,8 @@ import com.google.time.client.base.NetworkOperationResult;
 import com.google.time.client.base.Ticks;
 import com.google.time.client.base.impl.NoOpLogger;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeInstantSource;
+import com.google.time.client.base.testing.FakeTicker;
 import com.google.time.client.sntp.NtpProtocolException;
 import com.google.time.client.sntp.NtpServerNotReachableException;
 import com.google.time.client.sntp.SntpQueryDebugInfo;
@@ -268,7 +270,7 @@ public class SntpClientEngineNetworkingTest {
     FakeClocks fakeClientClocks = new FakeClocks();
     Instant clientStartInstant = Instant.ofEpochMilli(1234L);
     fakeClientClocks.getFakeInstantSource().setInstant(clientStartInstant);
-    FakeClocks.FakeTicker clientTicker = fakeClientClocks.getFakeTicker();
+    FakeTicker clientTicker = fakeClientClocks.getFakeTicker();
     clientTicker.setTicksValue(99999999);
     Ticks clientStartTicks = clientTicker.getCurrentTicks();
 
@@ -308,7 +310,7 @@ public class SntpClientEngineNetworkingTest {
     responseTemplate = responseTemplate.toBuilder().setHeader(responseHeaderTemplate).build();
     fakeSntpServerEngine.setLastResponseTemplate(responseTemplate);
 
-    FakeClocks.FakeInstantSource clientInstantSource = fakeClientClocks.getFakeInstantSource();
+    FakeInstantSource clientInstantSource = fakeClientClocks.getFakeInstantSource();
     SntpServiceConnector sntpServiceConnector =
         testSntpServerWithNetwork.createConnector(clientInstantSource, clientTicker);
     SntpClientEngine engine = new SntpClientEngine(NoOpLogger.instance(), sntpServiceConnector);

--- a/common/javatests/com/google/time/client/sntp/impl/SntpClientEngineUnitTest.java
+++ b/common/javatests/com/google/time/client/sntp/impl/SntpClientEngineUnitTest.java
@@ -28,6 +28,7 @@ import com.google.time.client.base.Duration;
 import com.google.time.client.base.Instant;
 import com.google.time.client.base.Ticks;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeTicker;
 import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -208,7 +209,7 @@ public class SntpClientEngineUnitTest {
   @Test
   public void performNtpCalculations() throws Exception {
     FakeClocks fakeClocks = new FakeClocks();
-    FakeClocks.FakeTicker ticker = fakeClocks.getFakeTicker();
+    FakeTicker ticker = fakeClocks.getFakeTicker();
 
     Timestamp64 requestTimestamp = Timestamp64.fromString("e4dc720c.4c0064aa");
 

--- a/common/javatests/com/google/time/client/sntp/impl/SntpQueryOperationTest.java
+++ b/common/javatests/com/google/time/client/sntp/impl/SntpQueryOperationTest.java
@@ -29,6 +29,8 @@ import com.google.time.client.base.Ticks;
 import com.google.time.client.base.impl.ClusteredServiceOperation.ServiceOperation.ServiceResult;
 import com.google.time.client.base.impl.NoOpLogger;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeInstantSource;
+import com.google.time.client.base.testing.FakeTicker;
 import com.google.time.client.base.testing.PredictableRandom;
 import com.google.time.client.sntp.BasicSntpClient;
 import com.google.time.client.sntp.NtpProtocolException;
@@ -56,9 +58,9 @@ public class SntpQueryOperationTest {
   private BasicSntpClient.ClientConfig clientConfig;
   private SntpRequestFactory requestFactory;
 
-  private FakeClocks.FakeTicker fakeClientTicker;
+  private FakeTicker fakeClientTicker;
 
-  private FakeClocks.FakeInstantSource fakeClientInstantSource;
+  private FakeInstantSource fakeClientInstantSource;
 
   @Before
   public void setUp() throws Exception {

--- a/common/javatests/com/google/time/client/sntp/impl/SntpRequestFactoryTest.java
+++ b/common/javatests/com/google/time/client/sntp/impl/SntpRequestFactoryTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotEquals;
 import com.google.time.client.base.Duration;
 import com.google.time.client.base.InstantSource;
 import com.google.time.client.base.testing.FakeClocks;
+import com.google.time.client.base.testing.FakeInstantSource;
 import com.google.time.client.base.testing.PredictableRandom;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +35,7 @@ public class SntpRequestFactoryTest {
   private static final int SNTP_CLIENT_VERSION = 3;
 
   private PredictableRandom random;
-  private FakeClocks.FakeInstantSource instantSource;
+  private FakeInstantSource instantSource;
 
   @Before
   public void setUp() {

--- a/javase/java/com/google/time/client/base/testing/FakeInstantSource.java
+++ b/javase/java/com/google/time/client/base/testing/FakeInstantSource.java
@@ -1,0 +1,1 @@
+../../../../../../../../common/java/com/google/time/client/base/testing/FakeInstantSource.java

--- a/javase/java/com/google/time/client/base/testing/FakeTicker.java
+++ b/javase/java/com/google/time/client/base/testing/FakeTicker.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.time.client.base.testing;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.time.client.base.Duration;
+import com.google.time.client.base.Ticker;
+import com.google.time.client.base.Ticks;
+import com.google.time.client.base.impl.Objects;
+
+/**
+ * A fake {@link Ticker} that can be used for tests. See {@link FakeClocks} for how to obtain an
+ * instance. This ticker simulates one that increments the tick value every nanosecond.
+ */
+public final class FakeTicker extends Ticker implements Advanceable {
+
+  private final FakeClocks fakeClocks;
+
+  private long ticksValue;
+
+  FakeTicker(FakeClocks fakeClocks) {
+    this.fakeClocks = Objects.requireNonNull(fakeClocks);
+  }
+
+  @Override
+  public Duration durationBetween(Ticks start, Ticks end) throws IllegalArgumentException {
+    return Duration.ofNanos(incrementsBetween(start, end));
+  }
+
+  @Override
+  public Ticks ticks() {
+    ticksValue += fakeClocks.autoAdvanceDuration.toNanos();
+    return getCurrentTicks();
+  }
+
+  /** Asserts the current ticks value matches the one supplied. Does not auto advance. */
+  public void assertCurrentTicks(Ticks actual) {
+    assertEquals(createTicks(ticksValue), actual);
+  }
+
+  /** Returns the current ticks value. Does not auto advance. */
+  public Ticks getCurrentTicks() {
+    return createTicks(ticksValue);
+  }
+
+  /** Returns a ticks value. Does not auto advance. */
+  public Ticks ticksForValue(long value) {
+    return createTicks(value);
+  }
+
+  /** Sets the current ticks value. Does not auto advance. */
+  public void setTicksValue(long ticksValue) {
+    this.ticksValue = ticksValue;
+  }
+
+  public void advanceNanos(long nanos) {
+    // FakeTicker.ticksValue is fixed to nanoseconds.
+    ticksValue += nanos;
+  }
+
+  @Override
+  public void advance(Duration duration) {
+    advanceNanos(duration.toNanos());
+  }
+
+  @Override
+  public String toString() {
+    return "FakeTicker{"
+        + "ticksValue="
+        + ticksValue
+        + ", fakeClocks.autoAdvanceDuration="
+        + fakeClocks.autoAdvanceDuration
+        + '}';
+  }
+}


### PR DESCRIPTION
Make FakeClocks Ticker implement AndroidTicker on Android. The client/base/testing class needs to be a drop-in replacement for PlatformTicker for some tests so an Android fork has been created.